### PR TITLE
Update 01-custom-engine-agent.md - UI change resulted nav change

### DIFF
--- a/docs/pages/custom-engine/01-custom-engine-agent.md
+++ b/docs/pages/custom-engine/01-custom-engine-agent.md
@@ -65,7 +65,7 @@ Once your Azure OpenAI service is created successfully, navigate to your resourc
 
 ### Step 2: Create a deployment model
 
-In your Azure OpenAI service, navigate to **Model deployments** from the left side panel, then select **Manage deployments**. This will direct you to `Azure AI Foundry` where you can create your deployment model.
+In your Azure OpenAI service, navigate to  `Azure AI Foundry` where you can create your deployment model.
 
 ??? check "What is Azure AI Foundry?"
     Azure AI Foundry is a playground to explore OpenAI models like `gpt-35-turbo`, `gpt-4` or `Dall-e` that helps you craft unique prompts for your use cases, and fine-tune your models. It's also a playground to models other than OpenAI such as `Phi-3`, `Llama 3.1` and a starting point to other Azure AI services such as Speech, Vision and more.


### PR DESCRIPTION
There's no "Model deployments" to navigate from Azure OpenAI service. Users can now directly go to "Azure AI Foundry" from the front page.